### PR TITLE
Correct CPU execution, instructions, and mapper reading for testing roms

### DIFF
--- a/src/CPU.cpp
+++ b/src/CPU.cpp
@@ -1,9 +1,6 @@
-#include ".\include\CPU_Opcodes.h"
+#include <algorithm>
 
-#include ".\include\Cartridge.h"
-#include ".\include\PPU.h"
-#include ".\include\APU.h"
-#include ".\include\Controller.h"
+#include ".\include\CPU_Opcodes.h"
 
 #include ".\include\RomStruct.h"
 
@@ -30,39 +27,49 @@ CPUClass::~CPUClass() {
 
 void CPUClass::reset() {
 
+	//	resetting costs 7 cycles, but we access to start later, so cycle 5 times now
+	this->cycle(); this->cycle(); this->cycle(); this->cycle(); this->cycle();
+
 	//	see following for state of console after reset: https://wiki.nesdev.com/w/index.php/CPU_power_up_state
+
+	std::fill(this->RAM.begin(), this->RAM.end(), 0x00);
 
 	this->registers.reg_SP = 0xFD;
 	this->setFlag(CPU_FLAGS::Interrupt);
 
 	uint16_t addr = 0xFFFC;
-	this->registers.reg_PC = (uint16_t)this->access(addr) | ((uint16_t)this->access(addr + 1) << 8);
 
-	/*
-	we still need to cover the APU changes here:
-		APU mode in $4017 was unchanged
-		APU was silenced ($4015 = 0)
-		APU triangle phase is reset to 0 (i.e. outputs a value of 15, the first step of its waveform)
-		APU DPCM output ANDed with 1 (upper 6 bits cleared)
-		2A03G: APU Frame Counter reset. (but 2A03letterless: APU frame counter retains old value)
-	*/
+	//	2 accesses, 2 cycles
+	this->cycle(); this->cycle();
+	this->registers.reg_PC = (uint16_t)this->access(addr) | ((uint16_t)this->access(addr + 1) << 8);
 
 }
 
 void CPUClass::cycle() {
 
-	//this->PPU->cycle(); this->PPU->cycle(); this->PPU->cycle();
-
+	//	CPU_test does not add the PPU, it only tests the CPU, so do not cycle the PPU at all
+#ifndef CPU_LOGGING
 	//	here we can check the system type(NTSC vs PAL) and call the PPU an equivalent number of times
-	//this->PPU->cycle(); this->PPU->cycle();
+	this->PPU->cycle(); this->PPU->cycle(); this->PPU->cycle();
 	if ((this->cartridge->getTV() == tvEnum::PAL) && (this->cycleCount % 5 == 0)) {
 
 		//	PAL version has a PPU to CPU ratio of 3.2:1
-		//this->PPU->cycle();
+		this->PPU->cycle();
 
 	}
+#endif
 
 	this->cycleCount++;
+	this->remainingCycles--;
+
+}
+
+void CPUClass::runFrame() {
+
+	this->remainingCycles += this->getFrameCycles();
+
+	while (this->remainingCycles > 0)
+		this->execute();
 
 }
 
@@ -70,20 +77,20 @@ void CPUClass::execute() {
 
 #ifdef CPU_LOGGING
 	this->logFile << "CYC: " << std::setw(10) << this->cycleCount
-			  << " PC: " << std::setw(10) << int_to_hex(this->registers.reg_PC)
-			  << " A: " << int_to_hex(this->registers.reg_A)
-			  << " X: " << int_to_hex(this->registers.reg_X)
-			  << " Y: " << int_to_hex(this->registers.reg_Y)
-			  << " FL: " << int_to_hex(this->registers.reg_FL)
-			  << " SP: " << int_to_hex(this->registers.reg_SP)
-			  << '\t';
+		<< " PC: " << std::setw(10) << int_to_hex(this->registers.reg_PC)
+		<< " A: " << int_to_hex(this->registers.reg_A)
+		<< " X: " << int_to_hex(this->registers.reg_X)
+		<< " Y: " << int_to_hex(this->registers.reg_Y)
+		<< " FL: " << int_to_hex(this->registers.reg_FL)
+		<< " SP: " << int_to_hex(this->registers.reg_SP)
+		<< '\t';
 #endif
 
 	if (this->NMI_INT) {
 
 		this->handleNMI();
-		
 		return;
+
 	}
 	if (this->IRQ_INT && (this->getFlagState(CPU_FLAGS::Interrupt) == false)) {
 
@@ -272,12 +279,6 @@ void CPUClass::execute() {
 
 }
 
-uint32_t CPUClass::getFrameCycles() {
-
-	return this->tvFrameCycleCount[this->cartridge->getTV()];
-
-}
-
 uint8_t CPUClass::access(uint16_t address, uint8_t data, bool isWrite) {
 
 	if (address <= 0x1FFF) {
@@ -290,47 +291,68 @@ uint8_t CPUClass::access(uint16_t address, uint8_t data, bool isWrite) {
 	else if (address <= 0x3FFF) {
 
 		//	PPU access
-		//return PPU->access(address, data, isWrite);
-		return 0;
+		if (isWrite)
+			this->PPU->write(address, data);
+		else
+			return this->PPU->read(address);
 
 	}
-	else if (address <= 0x4015) {
+	else if (address == 0x4014) {
+
+		//	PPU OAM DMA, can only write to this, see: https://wiki.nesdev.com/w/index.php/PPU_registers#OAM_DMA_.28.244014.29_.3E_write
+		if (isWrite) {
+
+			if (this->cycleCount & 1)
+				this->cycle();
+
+			for (uint32_t i = 0; i < 0x0100; i++) {
+
+				//	OAM DMA will write 256 bytes into the PPU's OAM memory
+				this->cycle();
+				uint8_t oamData = this->access((data * 0x0100) + i);
+				this->cycle();
+				this->PPU->write(0x2004, oamData);
+
+			}
+
+		}
+
+	}
+	else if (address == 0x4015) {
 
 		//	APU access
-		return 0;
 
 	}
 	else if (address == 0x4016) {
 
-		//	APU access or joystick 1
+		//	joystick 1 access
 		if (isWrite) {
 
 			//	verify that the controller is connected
 			if(this->controller)
-				this->controller->write();
+				this->controller->write(data & 1);
 			return 0;
 
 		}
 		if(this->controller)
 			return this->controller->read();
-		return 0;
 
 	}
 	else if (address == 0x4017) {
 
-		//	APU access or joystick 2
+		//	joystick 2 access
 		//	for now, we aren't even considering joystick 2
-		return 0;
 
 	}
 	else if (address <= 0x401F) {
 
-		//	typically disabled APU/IO access
-		return 0;
+		//	typically disabled, APU/IO access
 
 	}
 	else
 		return cartridge->prg_access(address, data, isWrite);
+
+	return 0;
 
 }
 

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -2,7 +2,7 @@
 
 #include ".\include\GUI.h"
 
-void ControllerClass::write() {
+void ControllerClass::write(bool data) {
 
 	//	Here we need to read the state of the keys pressed, and store them in the PISO shift register of the controller
 	this->PISO = this->GUI->getControllerState();

--- a/src/include/Controller.h
+++ b/src/include/Controller.h
@@ -8,7 +8,7 @@ class GUIClass;
 class ControllerClass {
 
 public:
-	void write();
+	void write(bool data);
 	uint8_t read();
 
 	void loadGUI(GUIClass* _GUI) { this->GUI = _GUI; }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,6 +24,9 @@ int main(int argc, char* argv[]) {
 	cpu.loadCartridge(&cartridge);
 	cpu.loadController(&controller);
 
+	ppu.loadCartridge(&cartridge);
+	ppu.loadGUI(&gui);
+
 	//	give GUI access to relevant components it needs to access
 	gui.loadCPU(&cpu);
 	gui.loadPPU(&ppu);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,3 @@
-#define SDL_MAIN_HANDLED
-
 #include <string>
 
 #include "..\..\src\include\CPU.h"
@@ -26,9 +24,6 @@ int main(int argc, char* argv[]) {
 	cpu.loadCartridge(&cartridge);
 	cpu.loadController(&controller);
 
-	//	give PPU access to relevant components
-	ppu.loadCartridge(&cartridge);
-
 	//	give GUI access to relevant components it needs to access
 	gui.loadCPU(&cpu);
 	gui.loadPPU(&ppu);
@@ -37,6 +32,7 @@ int main(int argc, char* argv[]) {
 	//	give the GUI the information it needs in order to create the windows for the various memory spaces
 	gui.addCPUViewer("CPU RAM", &CPUClass::get_cpu_ram, &CPUClass::get_cpu_ram_size);
 	gui.addCPUViewer("CPU Regs", &CPUClass::get_cpu_regs, &CPUClass::get_cpu_regs_size);
+
 	gui.addCartViewer("Cartridge PRG ROM", &CartridgeClass::get_prm_rom, &CartridgeClass::get_prm_rom_size);
 	gui.addCartViewer("Cartridge PRG RAM", &CartridgeClass::get_prg_ram, &CartridgeClass::get_prg_ram_size);
 	gui.addCartViewer("Cartridge CHR ROM", &CartridgeClass::get_chr_rom, &CartridgeClass::get_chr_rom_size);
@@ -44,7 +40,7 @@ int main(int argc, char* argv[]) {
 	while (gui.shouldRender()) {
 
 		if (!gui.paused() && gui.isLoaded())
-			cpu.execute();
+			cpu.runFrame();
 
 		gui.draw();
 

--- a/src/mappers/Mapper.cpp
+++ b/src/mappers/Mapper.cpp
@@ -8,6 +8,10 @@
 
 [[nodiscard]] uint8_t MapperClass::chr_read(uint16_t& address) {
 
+	//	safety check for CPU testing ROMs
+	if (this->rom->chr_rom.size() == 0)
+		return 0;
+
 	return this->rom->chr_rom.at(address);
 
 }

--- a/src/mappers/Mapper001.cpp
+++ b/src/mappers/Mapper001.cpp
@@ -32,6 +32,10 @@ Mapper001::Mapper001(romStruct* _rom) : MapperClass(_rom) {
 
 [[nodiscard]] uint8_t Mapper001::chr_read(uint16_t& address) {
 
+	//	safety check for CPU testing ROMs
+	if (this->rom->chr_rom.size() == 0)
+		return 0;
+
 	//	check if the address is in the first window section
 	if (address < 0x1000)
 		//	we want to window into a specific section at 4KB windows, so take the window offset, and multiply by 4096(0x1000)
@@ -89,6 +93,10 @@ uint8_t Mapper001::prg_write(uint16_t& address, const uint8_t& data) {
 }
 
 uint8_t Mapper001::chr_write(uint16_t& address, const uint8_t& data) {
+
+	//	safety check for CPU testing ROMs
+	if (this->rom->chr_rom.size() == 0)
+		return 0;
 
 	//	check if the address is in the first window section
 	if (address < 0x1000)

--- a/src/mappers/Mapper002.cpp
+++ b/src/mappers/Mapper002.cpp
@@ -26,6 +26,10 @@ Mapper002::Mapper002(romStruct* _rom) : MapperClass(_rom) {
 
 [[nodiscard]] uint8_t Mapper002::chr_read(uint16_t& address) {
 
+	//	safety check for CPU testing ROMs
+	if (this->rom->chr_rom.size() == 0)
+		return 0;
+
 	return this->rom->chr_rom.at((size_t)address & 0x1FFF);
 
 }
@@ -41,6 +45,10 @@ uint8_t Mapper002::prg_write(uint16_t& address, const uint8_t& data) {
 }
 
 uint8_t Mapper002::chr_write(uint16_t& address, const uint8_t& data) {
+
+	//	safety check for CPU testing ROMs
+	if (this->rom->chr_rom.size() == 0)
+		return 0;
 
 	return this->rom->chr_rom.at((size_t)address & 0x1FFF) = data;
 

--- a/src/mappers/Mapper003.cpp
+++ b/src/mappers/Mapper003.cpp
@@ -19,6 +19,10 @@ Mapper003::Mapper003(romStruct* _rom) : MapperClass(_rom) {
 
 [[nodiscard]] uint8_t Mapper003::chr_read(uint16_t& address) {
 
+	//	safety check for CPU testing ROMs
+	if (this->rom->chr_rom.size() == 0)
+		return 0;
+
 	return this->rom->chr_rom.at((size_t)address + ((size_t)this->chr_rom_window_1 * 0x2000));
 
 }
@@ -34,6 +38,10 @@ uint8_t Mapper003::prg_write(uint16_t& address, const uint8_t& data) {
 }
 
 uint8_t Mapper003::chr_write(uint16_t& address, const uint8_t& data) {
+
+	//	safety check for CPU testing ROMs
+	if (this->rom->chr_rom.size() == 0)
+		return 0;
 
 	return this->rom->chr_rom.at((size_t)address + ((size_t)this->chr_rom_window_1 * 0x2000)) = data;
 

--- a/tests/CPU_test/CPU_test.cpp
+++ b/tests/CPU_test/CPU_test.cpp
@@ -16,7 +16,7 @@ int main() {
 	cpu.reset();	//	we need to power the CPU to a known state
 
 	while (true)
-		cpu.execute();
+		cpu.runFrame();
 
 	return EXIT_SUCCESS;
 

--- a/vs/src/nes.vcxproj
+++ b/vs/src/nes.vcxproj
@@ -169,6 +169,7 @@
     <ClCompile Include="..\..\src\Controller.cpp" />
     <ClCompile Include="..\..\src\CPU.cpp" />
     <ClCompile Include="..\..\src\GUI.cpp" />
+    <ClCompile Include="..\..\src\main.cpp" />
     <ClCompile Include="..\..\src\mappers\Mapper.cpp" />
     <ClCompile Include="..\..\src\mappers\Mapper000.cpp" />
     <ClCompile Include="..\..\src\mappers\Mapper001.cpp" />
@@ -176,7 +177,6 @@
     <ClCompile Include="..\..\src\mappers\Mapper003.cpp" />
     <ClCompile Include="..\..\src\Mapper_Collection.cpp" />
     <ClCompile Include="..\..\src\PPU.cpp" />
-    <ClCompile Include="main.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\libs\imgui-sfml\imgui-SFML.h" />

--- a/vs/src/nes.vcxproj.filters
+++ b/vs/src/nes.vcxproj.filters
@@ -69,11 +69,11 @@
     <ClCompile Include="..\..\libs\imgui\imgui_widgets.cpp">
       <Filter>ImGui</Filter>
     </ClCompile>
-    <ClCompile Include="main.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\libs\imgui-sfml\imgui-SFML.cpp">
       <Filter>ImGui</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main.cpp">
+      <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Fixes various things with the CPU implementation, including opcodes for PHP and BRK, execution to now run at the number of CPU cycles per frame, and have the chr_rom and chr_ram return 0 if they are empty, to not cause crashes when running test roms that do not include either section.